### PR TITLE
fix: add missing environment variables

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -16,7 +16,8 @@ services:
 
     environment:
        - SPRING_PROFILES_ACTIVE=test
-
+       - SERVER_PORT=5000
+       - JWT_SECRET_KEY=docker-compose-test
     restart: no
 
     depends_on:


### PR DESCRIPTION
This pull request makes a small update to the test service configuration in `docker-compose-test.yml` by adding two environment variables to fix docker based testing. 

* Added `SERVER_PORT=5000` and `JWT_SECRET_KEY=docker-compose-test` to the test service environment variables in `docker-compose-test.yml`.